### PR TITLE
`polygon testnet mumbai` network name correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+./react/.env.json
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/react/.env.example.json
+++ b/react/.env.example.json
@@ -4,7 +4,7 @@
     "ropsten": "https://eth-ropsten.alchemyapi.io/v2/YOUR_KEY",
     "goerli": "https://eth-goerli.alchemyapi.io/v2/YOUR_KEY",
     "polygon": "etc",
-    "mumbai": "etc",
+    "polygon testnet mumbai": "etc",
     "mainnet": "etc",
     "localhost": "http://localhost:8545"
   }

--- a/react/.env.json
+++ b/react/.env.json
@@ -4,7 +4,7 @@
     "ropsten": "https://eth-ropsten.alchemyapi.io/v2/tDTu2vhfHnGOWJuM0p1DrA6BBJn0uDL3",
     "goerli": "https://eth-goerli.alchemyapi.io/v2/PHCB0UVg3sD5vc6TEqrPy-E37xOSUbg8",
     "polygon": "",
-    "mumbai": "https://polygon-mumbai.g.alchemy.com/v2/WIh5gM_qhPEIcs_70kEhI8F3vGUKMf6G",
+    "polygon testnet mumbai": "https://polygon-mumbai.g.alchemy.com/v2/WIh5gM_qhPEIcs_70kEhI8F3vGUKMf6G",
     "mainnet": "",
     "localhost": "http://localhost:8545"
   }

--- a/react/src/constants.ts
+++ b/react/src/constants.ts
@@ -10,7 +10,7 @@ interface NarratorParams {
 /***** CHANGE THEeSE!!! ????**/
 
 export const STORAGE_VERSION = "0.0.0"
-export const currentRelease = "mumbai"
+export const currentRelease = "polygon testnet mumbai"
 export let currentNarrator = 0
 export const localTestNarrator = 0
 
@@ -24,7 +24,7 @@ export const ADDRESSES: { [name: string]: string } = {
   "ropsten": "0x2A7b3033c100044178E7c7FDdC939Be660178458",
   "goerli": "0x6bb7758DB5b475B4208A5735A8023fdEdD753aaf",
   "polygon": "",
-  "mumbai": "0x9Ee5716bd64ec6e90e0a1F44C5eA346Cd0a8E5a4",
+  "polygon testnet mumbai": "0x9Ee5716bd64ec6e90e0a1F44C5eA346Cd0a8E5a4",
   "localhost": localhostAddress,
   // change in project root .env file! (avenluutn/.env is linked to avenluutn/react/.env)
 }
@@ -34,7 +34,7 @@ export const ADDRESSES: { [name: string]: string } = {
 let network
 if (window !== undefined) {
   if (window.location.host === '127.0.0.1:3000') {
-    network = "goerli" as NetworkName
+    network = "polygon testnet mumbai" as NetworkName
     currentNarrator = localTestNarrator
   }
 }
@@ -49,7 +49,7 @@ export const NETWORK_IDS: { [key in NetworkName]: number } = {
   "ropsten": 3,
   "goerli": 5,
   "polygon": 137,
-  "mumbai": 80001,
+  "polygon testnet mumbai": 80001,
   "localhost": 31337,
 }
 
@@ -68,7 +68,7 @@ export const SERVER = {
   "mainnet": "http://67.205.138.92",
   "ropsten": "http://67.205.138.92",
   "polygon": "https://avenluutn-api.squad.games",
-  "mumbai": "https://avenluutn-api.squad.games",
+  "polygon testnet mumbai": "https://avenluutn-api.squad.games",
   "goerli": "https://avenluutn-api-dev.squad.games",
 }[NARRATOR_PARAMS.network]
 
@@ -86,7 +86,7 @@ export const etherscanBases: { [key in NetworkName]: string } = {
   "ropsten": "https://ropsten.etherscan.io/",
   "mainnet": "https://www.etherscan.io/",
   "polygon": "https://polygonscan.com/",
-  "mumbai": "https://mumbai.polygonscan.com/",
+  "polygon testnet mumbai": "https://polygon testnet mumbai.polygonscan.com/",
   "goerli": "https://goerli.etherscan.io/",
   "localhost": "",
 }

--- a/react/src/hooks/useContractWritable.ts
+++ b/react/src/hooks/useContractWritable.ts
@@ -13,6 +13,7 @@ export default (contractAddress: string, abi: ContractInterface, network: string
   })
   const [{ data: currentNetwork }] = useNetwork()
   if (signer?.provider === undefined) return WARNINGS.no_connection
+  console.log('networks', network, "|", currentNetwork.chain?.name?.toLowerCase())
   if (network !== currentNetwork.chain?.name?.toLowerCase()) return WARNINGS.wrong_network
   return contract
 }

--- a/react/src/utils/types.ts
+++ b/react/src/utils/types.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ScriptResult, Story as StoryText, Success, Result } from '../../../scripts/src'
 
-export type NetworkName = "mainnet" | "ropsten" | "polygon" | "mumbai" | "localhost" | "goerli"
+export type NetworkName = "mainnet" | "ropsten" | "polygon" | "polygon testnet mumbai" | "localhost" | "goerli"
 
 export interface Notifications {
   warnings: string[];


### PR DESCRIPTION
Transactions couldn't be submitted on mumbai because we had the network name wrong. Apparently the real network name for mumbai is `polygon testnet mumbai` -- this PR should fix.